### PR TITLE
add namespace conflict trick to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ The goal of tidylog is to provide feedback about basic dplyr operations. It prov
 
 ## Example
 
-Load `tidylog` after `dplyr`:
+Load `tidylog` [*after*](https://github.com/elbersb/tidylog#namespace-conflicts) `dplyr`:
 
 ```{r message=FALSE}
 library("dplyr")
@@ -91,4 +91,19 @@ c <- select_if(mtcars, is.character)
 a <- band_members %>% left_join(band_instruments, by = "name")
 b <- band_members %>% full_join(band_instruments, by = "name")
 c <- band_members %>% anti_join(band_instruments, by = "name")
+```
+
+# Namespace conflicts
+
+Above, we recommended that users load `tidylog` *after* `dplyr`. This is because when two packages assign the same name to different functions, R gives precendence to the most recently loaded package. `tidylog` redefines several of the functions exported by `dplyr`, so it should be loaded last, otherwise the nice logs will not be printed.
+
+A safer and more explicit way to resolve such namespace conflicts is to use the [`conflicted` package](https://github.com/r-lib/conflicted):
+
+```{r}
+library(tidylog)
+library(conflicted)
+tidylog_functions <- getNamespaceExports("tidylog")
+for (f in tidylog_functions) {
+    conflicted::conflict_prefer(f, 'tidylog', quiet = TRUE)
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+tidylog
+=======
 
-# tidylog
+The goal of tidylog is to provide feedback about basic dplyr operations. It provides simple wrapper functions for the most common functions, such as `filter`, `mutate`, `select`, `full_join`, and `group_by`.
 
-The goal of tidylog is to provide feedback about basic dplyr operations.
-It provides simple wrapper functions for the most common functions, such
-as `filter`, `mutate`, `select`, `full_join`, and `group_by`.
+Example
+-------
 
-## Example
-
-Load `tidylog` after `dplyr`:
+Load `tidylog` [*after*](https://github.com/elbersb/tidylog#namespace-conflicts) `dplyr`:
 
 ``` r
 library("dplyr")
 library("tidylog", warn.conflicts = FALSE)
 ```
 
-Tidylog will give you feedback, for instance when filtering a data
-frame:
+Tidylog will give you feedback, for instance when filtering a data frame:
 
 ``` r
 filtered <- filter(mtcars, cyl == 4)
@@ -41,16 +39,17 @@ summary <- mtcars %>%
 #> filter: no rows removed
 ```
 
-Here, it might have been accidental that the last `filter` command had
-no effect.
+Here, it might have been accidental that the last `filter` command had no effect.
 
-## Installation
+Installation
+------------
 
 ``` r
 devtools::install_github("elbersb/tidylog")
 ```
 
-## More examples
+More examples
+-------------
 
 ### filter & distinct
 
@@ -115,4 +114,20 @@ b <- band_members %>% full_join(band_instruments, by = "name")
 #> full_join: added one row and added one column (plays)
 c <- band_members %>% anti_join(band_instruments, by = "name")
 #> anti_join: removed 2 rows and added no new columns
+```
+
+Namespace conflicts
+===================
+
+Above, we recommended that users load `tidylog` *after* `dplyr`. This is because when two packages assign the same name to different functions, R gives precendence to the most recently loaded package. `tidylog` redefines several of the functions exported by `dplyr`, so it should be loaded last, otherwise the nice logs will not be printed.
+
+A safer and more explicit way to resolve such namespace conflicts is to use the [`conflicted` package](https://github.com/r-lib/conflicted):
+
+``` r
+library(tidylog)
+library(conflicted)
+tidylog_functions <- getNamespaceExports("tidylog")
+for (f in tidylog_functions) {
+    conflicted::conflict_prefer(f, 'tidylog', quiet = TRUE)
+}
 ```


### PR DESCRIPTION
I've been having lots of namespace issues with dplyr, especially with the `select` and `filter` functions. As a result, I've gotten into the habit of calling the full `dplyr::select` everytime I use it.

Obviously, this won't work with `tidylog`, so I had to find a workaround. I thought the solution with `conflicted` was pretty neat, so I added it to your README in case some people find it useful.

Obviously, feel free to disregard if you don't think this is useful.

Thanks for the cool package!