### PR TITLE
Group indicator

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -40,9 +40,9 @@ log_filter <- function(.data, fun, funname, ...) {
     if (!"data.frame" %in% class(.data) | !should_display()) {
         return(newdata)
     }
-    
+
     group_status <- ifelse(dplyr::is.grouped_df(newdata), " (grouped)", "")
-    
+
     n <- nrow(.data) - nrow(newdata)
     if (n == 0) {
         display(glue::glue("{funname}{group_status}: no rows removed"))

--- a/R/filter.R
+++ b/R/filter.R
@@ -41,7 +41,7 @@ log_filter <- function(.data, fun, funname, ...) {
         return(newdata)
     }
     
-    group_status <- ifelse(dplyr::is.grouped_df(newdata), "(grouped)", "")
+    group_status <- ifelse(dplyr::is.grouped_df(newdata), " (grouped)", "")
     
     n <- nrow(.data) - nrow(newdata)
     if (n == 0) {

--- a/R/filter.R
+++ b/R/filter.R
@@ -40,14 +40,17 @@ log_filter <- function(.data, fun, funname, ...) {
     if (!"data.frame" %in% class(.data) | !should_display()) {
         return(newdata)
     }
+    
+    group_status <- ifelse(get_groups(newdata)[[1]] == 0, '', ' (grouped)')
+    
     n <- nrow(.data) - nrow(newdata)
     if (n == 0) {
-        display(glue::glue("{funname}: no rows removed"))
+        display(glue::glue("{funname}{group_status}: no rows removed"))
     } else if (n == nrow(.data)) {
-        display(glue::glue("{funname}: removed all rows (100%)"))
+        display(glue::glue("{funname}{group_status}: removed all rows (100%)"))
     } else {
         total <- nrow(.data)
-        display(glue::glue("{funname}: removed {n} out of {plural(total, 'row')} ",
+        display(glue::glue("{funname}{group_status}: removed {n} out of {plural(total, 'row')} ",
             "({percent(n, {total})})"))
     }
     newdata

--- a/R/filter.R
+++ b/R/filter.R
@@ -41,7 +41,7 @@ log_filter <- function(.data, fun, funname, ...) {
         return(newdata)
     }
     
-    group_status <- ifelse(get_groups(newdata)[[1]] == 0, '', ' (grouped)')
+    group_status <- ifelse(dplyr::is.grouped_df(newdata), "(grouped)", "")
     
     n <- nrow(.data) - nrow(newdata)
     if (n == 0) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -66,8 +66,8 @@ log_mutate <- function(.data, fun, funname, ...) {
         return(newdata)
     }
     
-    group_status <- ifelse(get_groups(newdata)[[1]] == 0, '', ' (grouped)')
-    
+    group_status <- ifelse(dplyr::is.grouped_df(newdata), "(grouped)", "")
+
     if (grepl("transmute", funname)) {
         dropped_vars <- setdiff(names(.data), names(newdata))
         n <- length(dropped_vars)

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -66,7 +66,7 @@ log_mutate <- function(.data, fun, funname, ...) {
         return(newdata)
     }
     
-    group_status <- ifelse(dplyr::is.grouped_df(newdata), "(grouped)", "")
+    group_status <- ifelse(dplyr::is.grouped_df(newdata), " (grouped)", "")
 
     if (grepl("transmute", funname)) {
         dropped_vars <- setdiff(names(.data), names(newdata))

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -61,11 +61,11 @@ transmute_at <- function(.data, ...) {
 log_mutate <- function(.data, fun, funname, ...) {
     cols <- names(.data)
     newdata <- fun(.data, ...)
-    
+
     if (!"data.frame" %in% class(.data) | !should_display()) {
         return(newdata)
     }
-    
+
     group_status <- ifelse(dplyr::is.grouped_df(newdata), " (grouped)", "")
 
     if (grepl("transmute", funname)) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -61,18 +61,21 @@ transmute_at <- function(.data, ...) {
 log_mutate <- function(.data, fun, funname, ...) {
     cols <- names(.data)
     newdata <- fun(.data, ...)
+    
     if (!"data.frame" %in% class(.data) | !should_display()) {
         return(newdata)
     }
-
+    
+    group_status <- ifelse(get_groups(newdata)[[1]] == 0, '', ' (grouped)')
+    
     if (grepl("transmute", funname)) {
         dropped_vars <- setdiff(names(.data), names(newdata))
         n <- length(dropped_vars)
         if (ncol(newdata) == 0) {
-            display(glue::glue("{funname}: dropped all variables"))
+            display(glue::glue("{funname}{group_status}: dropped all variables"))
             return(newdata)
         } else if (length(dropped_vars) > 0) {
-            display(glue::glue("{funname}: dropped {plural(n, 'variable')}",
+            display(glue::glue("{funname}{group_status}: dropped {plural(n, 'variable')}",
                            " ({format_list(dropped_vars)})"))
         }
     }
@@ -84,7 +87,7 @@ log_mutate <- function(.data, fun, funname, ...) {
             has_changed <- TRUE
             n <- length(unique(newdata[[var]]))
             p_na <- percent(sum(is.na(newdata[[var]])), length(newdata[[var]]))
-            display(glue::glue("{funname}: new variable '{var}' ",
+            display(glue::glue("{funname}{group_status}: new variable '{var}' ",
                 "with {plural(n, 'value', 'unique ')} and {p_na} NA"))
         } else {
             # new var
@@ -110,13 +113,13 @@ log_mutate <- function(.data, fun, funname, ...) {
                 levels_different <- any(levels(old) != levels(new))
 
                 if (n > 0 & levels_different) {
-                    display(glue::glue("{funname}: changed {plural(n, 'value')} ",
+                    display(glue::glue("{funname}{group_status}: changed {plural(n, 'value')} ",
                         "({p}) of '{var}', factor levels updated"))
                 } else if (n > 0 & !levels_different) {
-                    display(glue::glue("{funname}: changed {plural(n, 'value')} ",
+                    display(glue::glue("{funname}{group_status}: changed {plural(n, 'value')} ",
                         "({p}) of '{var}'"))
                 } else if (n == 0 & levels_different) {
-                    display(glue::glue("{funname}: factor levels of '{var}' changed"))
+                    display(glue::glue("{funname}{group_status}: factor levels of '{var}' changed"))
                 }
             } else if (typeold == typenew) {
                 # same type (except factor)
@@ -127,16 +130,16 @@ log_mutate <- function(.data, fun, funname, ...) {
                 n <- sum(different)
                 p <- percent(n, length(different))
                 new_na <- sum(is.na(new)) - sum(is.na(old))
-                display(glue::glue("{funname}: changed {plural(n, 'value')} ",
+                display(glue::glue("{funname}{group_status}: changed {plural(n, 'value')} ",
                     "({p}) of '{var}' ({new_na} new NA)"))
             } else {
                 # different type
                 new_na <- sum(is.na(new)) - sum(is.na(old))
                 if (new_na == length(new)) {
-                    display(glue::glue("{funname}: converted '{var}' from {typeold} ",
+                    display(glue::glue("{funname}{group_status}: converted '{var}' from {typeold} ",
                         "to {typenew} (now 100% NA)"))
                 } else {
-                    display(glue::glue("{funname}: converted '{var}' from {typeold} ",
+                    display(glue::glue("{funname}{group_status}: converted '{var}' from {typeold} ",
                         "to {typenew} ({new_na} new NA)"))
                 }
             }
@@ -144,7 +147,7 @@ log_mutate <- function(.data, fun, funname, ...) {
     }
 
     if (!has_changed) {
-        display(glue::glue("{funname}: no changes"))
+        display(glue::glue("{funname}{group_status}: no changes"))
     }
     newdata
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ summary <- mtcars %>%
 #> filter: removed 6 out of 32 rows (19%)
 #> mutate: new variable 'mpg_round' with 15 unique values and 0% NA
 #> group_by: 17 groups (cyl, mpg_round)
-#> filter: no rows removed
+#> filter (grouped): no rows removed
 ```
 
 Here, it might have been accidental that the last `filter` command had
@@ -127,7 +127,7 @@ c <- anti_join(band_members, band_instruments, by = "name")
 ## Turning logging off, registering additional loggers
 
 To turn off the output for just a particular function call, you can
-simply call the dplyr functions directly, e.g. `dplyr::filter`.
+simply call the dplyr functions directly, e.g. `dplyr::filter`.
 
 To turn off the output more permanently, set the global option
 `tidylog.display` to an empty list:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ summary <- mtcars %>%
 #> filter: removed 6 out of 32 rows (19%)
 #> mutate: new variable 'mpg_round' with 15 unique values and 0% NA
 #> group_by: 17 groups (cyl, mpg_round)
-#> filter (grouped): no rows removed
+#> filter(grouped): no rows removed
 ```
 
 Here, it might have been accidental that the last `filter` command had

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ summary <- mtcars %>%
 #> filter: removed 6 out of 32 rows (19%)
 #> mutate: new variable 'mpg_round' with 15 unique values and 0% NA
 #> group_by: 17 groups (cyl, mpg_round)
-#> filter(grouped): no rows removed
+#> filter (grouped): no rows removed
 ```
 
 Here, it might have been accidental that the last `filter` command had


### PR DESCRIPTION
In reference to ([issue #1](https://github.com/elbersb/tidylog/issues/1))

After a _group_by_, filter, mutate, and transmute will have a group tag.

``` r
library(dplyr)
library(tidylog)

c <-
  iris %>%
  transmute(x = Sepal.Length + Sepal.Width)
#> transmute: dropped 5 variables (Sepal.Length, Sepal.Width, Petal.Length, Petal.Width, Species)
#> transmute: new variable 'x' with 45 unique values and 0% NA

d <-
  iris %>%
  group_by(Species) %>%
  transmute(x = Sepal.Length + Sepal.Width) %>%
  filter(x > 0) %>%
  ungroup() %>%
  filter(x < 2)
#> group_by: 3 groups (Species)
#> transmute (grouped): dropped 4 variables (Sepal.Length, Sepal.Width, Petal.Length, Petal.Width)
#> transmute (grouped): new variable 'x' with 45 unique values and 0% NA
#> filter (grouped): no rows removed
#> filter: removed all rows (100%)
```

Created on 2019-02-06 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).