### PR TITLE
updated adjustment to Rd warnings

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -2,9 +2,9 @@
 #' that prints information about the operation
 #'
 #'
-#' @param x a tbl; see \link[dplyr-join]{inner_join}
-#' @param ... see \link[dplyr-join]{inner_join}
-#' @return see \link[dplyr-join]{inner_join}
+#' @param x a tbl; see \link[dplyr:join]{inner_join}
+#' @param ... see \link[dplyr:join]{inner_join}
+#' @return see \link[dplyr:join]{inner_join}
 #' @import dplyr
 #' @export
 inner_join <- function(x, ...) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -31,9 +31,9 @@ mutate_at <- function(.data, ...) {
 #' Wrapper around dplyr::transmute and related functions
 #' that prints information about the operation
 #'
-#' @param .data a tbl; see \link[dplyr:mutate]{dplyr::transmute()}
-#' @param ... see \link[dplyr:mutate]{dplyr::transmute()}
-#' @return see \link[dplyr:mutate]{dplyr::transmute()}
+#' @param .data a tbl; see \link[dplyr:mutate]{transmute}
+#' @param ... see \link[dplyr:mutate]{transmute}
+#' @return see \link[dplyr:mutate]{transmute}
 #' @import dplyr
 #' @export
 transmute <- function(.data, ...) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -31,9 +31,9 @@ mutate_at <- function(.data, ...) {
 #' Wrapper around dplyr::transmute and related functions
 #' that prints information about the operation
 #'
-#' @param .data a tbl; see \link[dplyr]{transmute}
-#' @param ... see \link[dplyr]{transmute}
-#' @return see \link[dplyr]{transmute}
+#' @param .data a tbl; see \link[dplyr-transmute]{transmute}
+#' @param ... see \link[dplyr-transmute]{transmute}
+#' @return see \link[dplyr-transmute]{transmute}
 #' @import dplyr
 #' @export
 transmute <- function(.data, ...) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -31,9 +31,9 @@ mutate_at <- function(.data, ...) {
 #' Wrapper around dplyr::transmute and related functions
 #' that prints information about the operation
 #'
-#' @param .data a tbl; see \link[dplyr-transmute]{transmute}
-#' @param ... see \link[dplyr-transmute]{transmute}
-#' @return see \link[dplyr-transmute]{transmute}
+#' @param .data a tbl; see \link[dplyr:mutate]{dplyr::transmute()}
+#' @param ... see \link[dplyr:mutate]{dplyr::transmute()}
+#' @return see \link[dplyr:mutate]{dplyr::transmute()}
 #' @import dplyr
 #' @export
 transmute <- function(.data, ...) {

--- a/man/inner_join.Rd
+++ b/man/inner_join.Rd
@@ -23,12 +23,12 @@ anti_join(x, ...)
 semi_join(x, ...)
 }
 \arguments{
-\item{x}{a tbl; see \link[dplyr]{inner_join}}
+\item{x}{a tbl; see \link[dplyr-join]{inner_join}}
 
-\item{...}{see \link[dplyr]{inner_join}}
+\item{...}{see \link[dplyr-join]{inner_join}}
 }
 \value{
-see \link[dplyr]{inner_join}
+see \link[dplyr-join]{inner_join}
 }
 \description{
 Wrapper around dplyr::inner_join and related functions

--- a/man/inner_join.Rd
+++ b/man/inner_join.Rd
@@ -23,12 +23,12 @@ anti_join(x, ...)
 semi_join(x, ...)
 }
 \arguments{
-\item{x}{a tbl; see \link[dplyr-join]{inner_join}}
+\item{x}{a tbl; see \link[dplyr:join]{inner_join}}
 
-\item{...}{see \link[dplyr-join]{inner_join}}
+\item{...}{see \link[dplyr:join]{inner_join}}
 }
 \value{
-see \link[dplyr-join]{inner_join}
+see \link[dplyr:join]{inner_join}
 }
 \description{
 Wrapper around dplyr::inner_join and related functions

--- a/man/transmute.Rd
+++ b/man/transmute.Rd
@@ -17,12 +17,12 @@ transmute_if(.data, ...)
 transmute_at(.data, ...)
 }
 \arguments{
-\item{.data}{a tbl; see \link[dplyr-transmute]{transmute}}
+\item{.data}{a tbl; see \link[dplyr:mutate]{transmute}}
 
-\item{...}{see \link[dplyr-transmute]{transmute}}
+\item{...}{see \link[dplyr:mutate]{transmute}}
 }
 \value{
-see \link[dplyr-transmute]{transmute}
+see \link[dplyr:mutate]{transmute}
 }
 \description{
 Wrapper around dplyr::transmute and related functions

--- a/man/transmute.Rd
+++ b/man/transmute.Rd
@@ -17,12 +17,12 @@ transmute_if(.data, ...)
 transmute_at(.data, ...)
 }
 \arguments{
-\item{.data}{a tbl; see \link[dplyr]{transmute}}
+\item{.data}{a tbl; see \link[dplyr-transmute]{transmute}}
 
-\item{...}{see \link[dplyr]{transmute}}
+\item{...}{see \link[dplyr-transmute]{transmute}}
 }
 \value{
-see \link[dplyr]{transmute}
+see \link[dplyr-transmute]{transmute}
 }
 \description{
 Wrapper around dplyr::transmute and related functions


### PR DESCRIPTION
Updated to use
`@param x a tbl; see \link[dplyr:join]{inner_join}`
and 
`@param .data a tbl; see \link[dplyr:mutate]{transmute}`

To avoid install warning

Yes, this is probably something that should be handled by roxygen, but it's been an issue for over a year, so I'm not sure it's high on their list