### PR TITLE
slice_min/max now report number of rows with ties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # tidylog (development version)
 
 - use cli instead of clisymbols
-- dplyr: use of join_by syntax with comparisons other than `==` now reports changed row counts.
+- dplyr: use of join_by syntax with comparisons other than `==` now reports changed row counts (#74).
+- slice_min/max now report number of ties (#66)
 
 # 1.1.0
 

--- a/R/display_changed_rows.R
+++ b/R/display_changed_rows.R
@@ -1,3 +1,14 @@
+# Formats `.funname` with "(grouped)" if appropriate.
+format_funname_prefix <- function(.funname, .newdata) {
+    if(dplyr::is.grouped_df(.newdata) == TRUE) {
+        prefix <- paste0(.funname, " (grouped)")
+    } else {
+        prefix <- .funname
+    }
+
+    paste0(prefix, ": ")
+}
+
 #' Displays messages related to changing row number.
 #'
 #' @description Unlike `log_...()` functions, this assumes the data manipulation
@@ -13,24 +24,23 @@ display_changed_rows <- function(.olddata, .newdata, .funname) {
         return()
     }
 
+    funname_prefix <- format_funname_prefix(.funname, .newdata)
+
     if (dplyr::is.grouped_df(.newdata) == TRUE) {
-        group_status <- " (grouped)"
         groups_diff <- dplyr::n_groups(.olddata) - dplyr::n_groups(.newdata)
         group_desc <- glue::glue(" (removed {plural(groups_diff, 'group')}, {plural(dplyr::n_groups(.newdata), 'group')} remaining)")
     } else {
-        group_status <- ""
         group_desc <- ""
     }
 
     n <- nrow(.olddata) - nrow(.newdata)
     if (n == 0) {
-        display(glue::glue("{.funname}{group_status}: no rows removed"))
+        display(glue::glue("{funname_prefix}no rows removed"))
     } else if (n == nrow(.olddata)) {
-        display(glue::glue("{.funname}{group_status}: removed all rows (100%)"))
+        display(glue::glue("{funname_prefix}removed all rows (100%)"))
     } else {
         total <- nrow(.olddata)
-        display(glue::glue("{.funname}{group_status}: ",
-                           "removed {plural(n, 'row')} ",
+        display(glue::glue("{funname_prefix}removed {plural(n, 'row')} ",
                            "({percent(n, {total})}), {plural(nrow(.newdata), 'row')} remaining{group_desc}"))
     }
 }

--- a/R/filter.R
+++ b/R/filter.R
@@ -102,6 +102,9 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
     # The default is `with_ties=TRUE`, so we only check for explicit FALSE.
     if(isFALSE(dots$with_ties)) return()
 
+    # Evaluate funname_prefix before converting .newdata to explicit grouping.
+    funname_prefix <- format_funname_prefix(.funname, .newdata)
+
     # Use explicit grouping when evaluating by= grouping.
     if(!is.null(dots$by)) {
         .olddata <- dplyr::group_by(.olddata, dplyr::across(!!dots$by))
@@ -139,7 +142,6 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
         glue::glue(" (across {num_groups})",
                    num_groups=plural(num_groups_with_ties, "group"))
     }
-    funname_prefix <- format_funname_prefix(.funname, .newdata)
     ws_pre <- paste0(rep(" ", nchar(funname_prefix)), collapse = "")
     display(glue::glue(
         "{ws_pre}{total_diff} rows are ties{group_suffix}"

--- a/R/filter.R
+++ b/R/filter.R
@@ -103,11 +103,6 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
     # (The unspecified default is `with_ties=TRUE`.)
     if(isFALSE(dots$with_ties)) return()
 
-    # Evaluate funname_prefix before converting .newdata to explicit grouping.
-    funname_prefix <- format_funname_prefix(.funname, .newdata)
-    ws_pre <- paste0(rep(" ", nchar(funname_prefix)), collapse = "")
-    with_ties_prefix <- "with_ties: "
-
     # Use explicit grouping when evaluating `by=` grouping.
     if(!is.null(dots$by)) {
         .olddata <- dplyr::group_by(.olddata, dplyr::across(!!dots$by))
@@ -136,8 +131,11 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
     # Only display something if ties are found.
     if (total_diff > 0)
     {
+        funname_prefix <- format_funname_prefix(.funname, .newdata)
+        ws_pre <- paste0(rep(" ", nchar(funname_prefix)), collapse = "")
+
         display(glue::glue(
-            "{ws_pre}{with_ties_prefix}{total_diff} rows are ties"
+            "{ws_pre}with_ties: {total_diff} rows are ties"
         ))
     }
 

--- a/R/filter.R
+++ b/R/filter.R
@@ -96,6 +96,7 @@ drop_na <- function(data, ...) {
 }
 
 display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
+    # We must use enquos to account for the NSE of variable names.
     dots <- rlang::enquos(...)
 
     # The default is `with_ties=TRUE`, so we only check for explicit FALSE.

--- a/R/filter.R
+++ b/R/filter.R
@@ -129,18 +129,21 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
     group_size_diff <- new_group_sizes - expected_n
     total_diff <- sum(group_size_diff)
     num_groups_with_ties <- sum(group_size_diff > 0)
-    if(num_groups_with_ties > 0) {
-        group_suffix <- if(num_groups_with_ties == 1) {
-            ""
-        } else {
-            glue::glue(" (across {num_groups})",
-                       num_groups=plural(num_groups_with_ties, "group"))
-        }
-
-        display(glue::glue(
-            "{.funname}: {total_diff} rows are ties{group_suffix}"
-        ))
+    if (num_groups_with_ties == 0) {
+        return()
     }
+
+    group_suffix <- if(num_groups_with_ties == 1) {
+        ""
+    } else {
+        glue::glue(" (across {num_groups})",
+                   num_groups=plural(num_groups_with_ties, "group"))
+    }
+    funname_prefix <- format_funname_prefix(.funname, .newdata)
+    ws_pre <- paste0(rep(" ", nchar(funname_prefix)), collapse = "")
+    display(glue::glue(
+        "{ws_pre}{total_diff} rows are ties{group_suffix}"
+    ))
 }
 
 log_filter <- function(.data, .fun, .funname, ...) {

--- a/R/filter.R
+++ b/R/filter.R
@@ -104,8 +104,8 @@ display_slice_ties <- function(.olddata, .newdata, .funname, ...) {
 
     # Use explicit grouping when evaluating by= grouping.
     if(!is.null(dots$by)) {
-        .olddata <- dplyr::group_by(.olddata, !!!dots$by)
-        .newdata <- dplyr::group_by(.newdata, !!!dots$by)
+        .olddata <- dplyr::group_by(.olddata, dplyr::across(!!dots$by))
+        .newdata <- dplyr::group_by(.newdata, dplyr::across(!!dots$by))
     }
 
     # slice_min/max don't change number of groups.

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -257,3 +257,15 @@ test_that("slice_max with ties", {
                       message = ungrouped_msg)
 
 })
+
+test_that("slice_min/max with_ties=TRUE and multiple groups", {
+    expect_message(
+        tidylog::slice_min(mtcars, carb, by=c(am, gear), n=1),
+        ".*slice_min: 7 rows are ties \\(across 4 groups\\)"
+    )
+
+    expect_message(
+        tidylog::slice_max(mtcars, carb, by=c(am, gear), n=1),
+        ".*slice_max: 6 rows are ties \\(across 3 groups\\)"
+    )
+})

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -187,3 +187,73 @@ test_that("filter on grouped data", {
         out <- tidylog::filter(gb, am == 0)
     }, "removed one group, 2 groups remaining")
 })
+
+test_that("slice_min with ties", {
+
+    build_msg <- function(nties, ngroups) {
+        group_suffix <- if(ngroups == 1) "" else glue::glue(" \\(across {ngroups} groups\\)")
+        glue::glue(".*slice_min: {nties} rows are ties{group_suffix}")
+    }
+
+    grouped_n_msg <- build_msg(6, 3)  # n=1
+    grouped_prop_msg <- build_msg(3, 2)  # prop=0.2
+
+    # Grouped explicitly
+    gb <- dplyr::group_by(mtcars, gear)
+    expect_message(tidylog::slice_min(gb, carb), grouped_n_msg)
+    expect_message(tidylog::slice_min(gb, carb, n=1), grouped_n_msg)
+    expect_message(tidylog::slice_min(gb, carb, prop=0.2), grouped_prop_msg)
+    expect_no_message(tidylog::slice_min(gb, carb, with_ties = FALSE),
+                      message = grouped_n_msg)
+
+    # Grouped using by=
+    expect_message(tidylog::slice_min(mtcars, carb, by=gear), grouped_n_msg)
+    expect_message(tidylog::slice_min(mtcars, carb, by=gear, n=1), grouped_n_msg)
+    expect_message(tidylog::slice_min(mtcars, carb, by=gear, prop=0.2), grouped_prop_msg)
+    expect_no_message(tidylog::slice_min(mtcars, carb, by=gear, with_ties = FALSE),
+                      message = grouped_n_msg)
+
+    # Ungrouped
+    ungrouped_msg <- ".*slice_min: 6 rows are ties"
+    expect_message(tidylog::slice_min(mtcars, carb), ungrouped_msg)
+    expect_message(tidylog::slice_min(mtcars, carb, n=1), ungrouped_msg)
+    expect_message(tidylog::slice_min(mtcars, carb, prop=0.04), ungrouped_msg)
+    expect_no_message(tidylog::slice_min(mtcars, carb, with_ties = FALSE),
+                      message = ungrouped_msg)
+
+})
+
+test_that("slice_max with ties", {
+
+    build_msg <- function(nties, ngroups) {
+        group_suffix <- if(ngroups == 1) "" else glue::glue(" \\(across {ngroups} groups\\)")
+        glue::glue(".*slice_max: {nties} rows are ties{group_suffix}")
+    }
+
+    grouped_n_msg <- build_msg(7, 2)
+    grouped_prop_msg <- build_msg(4, 2)
+
+    # Grouped explicitly
+    gb <- dplyr::group_by(mtcars, gear)
+    expect_message(tidylog::slice_max(gb, carb), grouped_n_msg)
+    expect_message(tidylog::slice_max(gb, carb, n=1), grouped_n_msg)
+    expect_message(tidylog::slice_max(gb, carb, prop=0.2), grouped_prop_msg)
+    expect_no_message(tidylog::slice_max(gb, carb, with_ties = FALSE),
+                      message = grouped_n_msg)
+
+    # Grouped using by=
+    expect_message(tidylog::slice_max(mtcars, carb, by=gear), grouped_n_msg)
+    expect_message(tidylog::slice_max(mtcars, carb, by=gear, n=1), grouped_n_msg)
+    expect_message(tidylog::slice_max(mtcars, carb, by=gear, prop=0.2), grouped_prop_msg)
+    expect_no_message(tidylog::slice_max(mtcars, carb, by=gear, with_ties = FALSE),
+                      message = grouped_n_msg)
+
+    # Ungrouped
+    ungrouped_msg <- ".*slice_max: 13 rows are ties"
+    expect_message(tidylog::slice_max(mtcars, vs), ungrouped_msg)
+    expect_message(tidylog::slice_max(mtcars, vs, n=1), ungrouped_msg)
+    expect_message(tidylog::slice_max(mtcars, vs, prop=0.04), ungrouped_msg)
+    expect_no_message(tidylog::slice_max(mtcars, vs, with_ties = FALSE),
+                      message = ungrouped_msg)
+
+})

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -188,15 +188,15 @@ test_that("filter on grouped data", {
     }, "removed one group, 2 groups remaining")
 })
 
+build_ties_msg <- function(nties, ngroups) {
+    group_suffix <- if(ngroups == 1) "" else glue::glue(" \\(across {ngroups} groups\\)")
+    glue::glue(".*{nties} rows are ties{group_suffix}")
+}
+
 test_that("slice_min with ties", {
 
-    build_msg <- function(nties, ngroups) {
-        group_suffix <- if(ngroups == 1) "" else glue::glue(" \\(across {ngroups} groups\\)")
-        glue::glue(".*slice_min: {nties} rows are ties{group_suffix}")
-    }
-
-    grouped_n_msg <- build_msg(6, 3)  # n=1
-    grouped_prop_msg <- build_msg(3, 2)  # prop=0.2
+    grouped_n_msg <- build_ties_msg(6, 3)  # n=1
+    grouped_prop_msg <- build_ties_msg(3, 2)  # prop=0.2
 
     # Grouped explicitly
     gb <- dplyr::group_by(mtcars, gear)
@@ -214,7 +214,7 @@ test_that("slice_min with ties", {
                       message = grouped_n_msg)
 
     # Ungrouped
-    ungrouped_msg <- ".*slice_min: 6 rows are ties"
+    ungrouped_msg <- ".*6 rows are ties"
     expect_message(tidylog::slice_min(mtcars, carb), ungrouped_msg)
     expect_message(tidylog::slice_min(mtcars, carb, n=1), ungrouped_msg)
     expect_message(tidylog::slice_min(mtcars, carb, prop=0.04), ungrouped_msg)
@@ -225,13 +225,8 @@ test_that("slice_min with ties", {
 
 test_that("slice_max with ties", {
 
-    build_msg <- function(nties, ngroups) {
-        group_suffix <- if(ngroups == 1) "" else glue::glue(" \\(across {ngroups} groups\\)")
-        glue::glue(".*slice_max: {nties} rows are ties{group_suffix}")
-    }
-
-    grouped_n_msg <- build_msg(7, 2)
-    grouped_prop_msg <- build_msg(4, 2)
+    grouped_n_msg <- build_ties_msg(7, 2)
+    grouped_prop_msg <- build_ties_msg(4, 2)
 
     # Grouped explicitly
     gb <- dplyr::group_by(mtcars, gear)
@@ -249,7 +244,7 @@ test_that("slice_max with ties", {
                       message = grouped_n_msg)
 
     # Ungrouped
-    ungrouped_msg <- ".*slice_max: 13 rows are ties"
+    ungrouped_msg <- ".*13 rows are ties"
     expect_message(tidylog::slice_max(mtcars, vs), ungrouped_msg)
     expect_message(tidylog::slice_max(mtcars, vs, n=1), ungrouped_msg)
     expect_message(tidylog::slice_max(mtcars, vs, prop=0.04), ungrouped_msg)
@@ -261,11 +256,11 @@ test_that("slice_max with ties", {
 test_that("slice_min/max with_ties=TRUE and multiple groups", {
     expect_message(
         tidylog::slice_min(mtcars, carb, by=c(am, gear), n=1),
-        ".*slice_min: 7 rows are ties \\(across 4 groups\\)"
+        ".*7 rows are ties \\(across 4 groups\\)"
     )
 
     expect_message(
         tidylog::slice_max(mtcars, carb, by=c(am, gear), n=1),
-        ".*slice_max: 6 rows are ties \\(across 3 groups\\)"
+        ".*6 rows are ties \\(across 3 groups\\)"
     )
 })


### PR DESCRIPTION
#66 

To keep these changes separate from `display_changed_rows`, I implemented this as a follow-up line to the standard slice_max: removed XXX rows.

e.g.
```
slice_max (grouped): removed 22 rows (69%), 10 rows remaining (removed 0 groups, 3 groups remaining)
slice_max: 4 rows are ties (across 2 groups)
```

See tests for more examples.